### PR TITLE
Fix broken siphash implementation

### DIFF
--- a/src/main/java/net/wigle/m8b/siphash/SipHash.java
+++ b/src/main/java/net/wigle/m8b/siphash/SipHash.java
@@ -27,19 +27,19 @@ public class SipHash {
 
         switch (data.length % 8) {
             case 7: 
-                last |= ((long) data[off + 6]) << 48;
+                last |= (((long) data[off + 6]) & 0xff) << 48;
             case 6:
-                last |= ((long) data[off + 5]) << 40;
+                last |= (((long) data[off + 5]) & 0xff) << 40;
             case 5:
-                last |= ((long) data[off + 4]) << 32;
+                last |= (((long) data[off + 4]) & 0xff) << 32;
             case 4:
-                last |= ((long) data[off + 3]) << 24;
+                last |= (((long) data[off + 3]) & 0xff) << 24;
             case 3:
-                last |= ((long) data[off + 2]) << 16;
+                last |= (((long) data[off + 2]) & 0xff) << 16;
             case 2:
-                last |= ((long) data[off + 1]) << 8;
+                last |= (((long) data[off + 1]) & 0xff) << 8;
             case 1:
-                last |= (long) data[off];
+                last |= ((long) data[off]) & 0xff;
                 break;
             case 0:
                 break;

--- a/src/main/java/net/wigle/m8b/siphash/UnsignedInt64.java
+++ b/src/main/java/net/wigle/m8b/siphash/UnsignedInt64.java
@@ -12,14 +12,14 @@ class UnsignedInt64 {
     }
     
     public static long binToIntOffset(byte[] b, int off) {
-        return ((long) b[off    ])       |
-               ((long) b[off + 1]) << 8  |
-               ((long) b[off + 2]) << 16 |
-               ((long) b[off + 3]) << 24 |
-               ((long) b[off + 4]) << 32 |
-               ((long) b[off + 5]) << 40 |
-               ((long) b[off + 6]) << 48 |
-               ((long) b[off + 7]) << 56;
+        return (((long) b[off    ]) & 0xff)     |
+               (((long) b[off + 1]) & 0xff) << 8  |
+               (((long) b[off + 2]) & 0xff) << 16 |
+               (((long) b[off + 3]) & 0xff) << 24 |
+               (((long) b[off + 4]) & 0xff) << 32 |
+               (((long) b[off + 5]) & 0xff) << 40 |
+               (((long) b[off + 6]) & 0xff) << 48 |
+               (((long) b[off + 7]) & 0xff) << 56;
     }
     
     public static void intToBin(long l, byte[] b) {


### PR DESCRIPTION
This project uses a broken java implementation of siphash from https://github.com/emboss/siphash-java which makes the m8b files produced unusable with systems which use a correct siphash.

The siphash-java project has had on open pull request with a [fix](https://github.com/emboss/siphash-java/pull/2) for this issue for close to a decade, but that project is dead.

This PR contains the fix applied to the siphash java sources in m8b.

Could you please apply the fix and make a new release of [m8binary](https://github.com/wiglenet/m8binary), with a fresh data import?